### PR TITLE
Add bullet points on cgo and heap allocations

### DIFF
--- a/performance.md
+++ b/performance.md
@@ -61,6 +61,12 @@ Techniques applicable to source code in general
 * Comment about Jeff Dean's 2002 numbers (plus updates)
   * cpus have gotten faster, but memory hasn't kept up
 
+## Heap Allocations
+* Stack vs. heap allocations
+* What causes heap allocations?
+* Understanding escape analysis
+* Using sync.Pool effectively
+
 ## Runtime
 * cost of calls via interfaces (indirect calls on the CPU level)
 * runtime.convT2E / runtime.convT2I

--- a/performance.md
+++ b/performance.md
@@ -86,6 +86,11 @@ Techniques applicable to source code in general
 * mmap'ing data files
 * speedy de-serialization
 
+## cgo
+* Performance characteristics of cgo calls
+* Tricks to reduce the costs
+* Passing pointers between Go and C
+
 ## Assembly
 * Stuff about writing assembly code for Go
 * brief into to syntax


### PR DESCRIPTION
Hi @dgryski.

I saw on the Go slack in #performance that you were asking for help in filling out this repo. I think it's a pretty interesting idea that sounds like it could be fun to do some writing on. So, this is me dipping my first toe in those waters.

In this pull request I've added some bullet points to performance.md about heap allocations and cgo. I would love to discuss more about how you want to turn this into a more proper book, but let's just start here.
