### PR TITLE
Adding a note on benchmarking on the correct target platform

### DIFF
--- a/performance.md
+++ b/performance.md
@@ -14,7 +14,7 @@ All the content will be licensed under CC-BY-SA.
     1. profile to identify the areas to improve.  This can be CPU, heap allocations, or goroutine blocking.
     1. benchmark to determine the speed up your solution will provide using
        the built-in benchmarking framework (<http://golang.org/pkg/testing/>)
-       Make sure you're benchmarking the right thing.
+       Make sure you're benchmarking the right thing, and benchmarking it on your target operating system and architecture. Benchmarking on your macbook is not the same as benchmarking in a production-like environment.
     1. profile again afterwards to verify the issue is gone
     1. use <https://godoc.org/golang.org/x/perf/benchstat> or
        <https://github.com/codahale/tinystat> to verify that a set of timings

--- a/performance.md
+++ b/performance.md
@@ -116,7 +116,7 @@ Techniques applicable to source code in general
 
 ## Assembly
 * Stuff about writing assembly code for Go
-* brief into to syntax
+* brief intro to syntax
 * calling convention
 * using opcodes unsupported by the asm
 * notes about why intrinsics are hard


### PR DESCRIPTION
@dgryski was reading through the doc, and noticed something I felt was missing from the notes on the proper benchmarking approach. 

Happy to update the language, or you can simply make the change if you think it makes sense.